### PR TITLE
Initialize variable data in any case

### DIFF
--- a/rpl/variable.h
+++ b/rpl/variable.h
@@ -158,7 +158,7 @@ private:
 		return *this;
 	}
 
-	Type _data;
+	Type _data{};
 	event_stream<Type, Error> _changes;
 	lifetime _lifetime;
 


### PR DESCRIPTION
I found that the `rpl::variable<int>::assign` method may compare uninitialized yet member `_data`.

```
==121545== Conditional jump or move depends on uninitialised value(s)
==121545==    at 0xB11BEF: rpl::variable<int, rpl::no_error>& rpl::variable<int, rpl::no_error>::assign<int>(int&&) (variable.h:144)
==121545==    by 0x1418C05: auto rpl::variable<int, rpl::no_error>::variable<int, rpl::no_error, rpl::details::type_erased_generator<int, rpl::no_error>, void>(rpl::producer<int, rpl::no_error, rpl::details::type_erased_generator<int, rpl::no_error> >&&)::{lambda(auto:1&&)#1}::operator()<int>(int&&) const (variable.h:83)
...
```