### PR TITLE
Removed deprecated GSL headers usage

### DIFF
--- a/rpl/consumer.h
+++ b/rpl/consumer.h
@@ -7,7 +7,7 @@
 #pragma once
 
 #include <memory>
-#include <gsl/gsl_assert>
+#include <gsl/assert>
 #include <rpl/lifetime.h>
 #include <rpl/details/callable.h>
 


### PR DESCRIPTION
Removed deprecated GSL headers usage:

```
In file included from /builddir/build/BUILD/tdesktop-4.6.2-full/Telegram/lib_rpl/rpl/consumer.h:10,
                 from /builddir/build/BUILD/tdesktop-4.6.2-full/Telegram/lib_rpl/rpl/producer.h:10,
                 from /builddir/build/BUILD/tdesktop-4.6.2-full/Telegram/lib_crl/crl/crl_on_main.h:27,
                 from /builddir/build/BUILD/tdesktop-4.6.2-full/Telegram/SourceFiles/payments/smartglocal/smartglocal_api_client.cpp:17:
/usr/include/gsl/gsl_assert:2:97: note: '#pragma message: This header will soon be removed. Use <gsl/assert> instead of <gsl/gsl_assert>'
    2 | #pragma message("This header will soon be removed. Use <gsl/assert> instead of <gsl/gsl_assert>")
      |                                                                                                 ^
```